### PR TITLE
Hide sound errors

### DIFF
--- a/src/main/kotlin/dulkirmod/features/chat/AbiphoneDND.kt
+++ b/src/main/kotlin/dulkirmod/features/chat/AbiphoneDND.kt
@@ -19,7 +19,10 @@ class AbiphoneDND {
         if (System.currentTimeMillis() - lastRing < 5000) {
             if (event.name == "note.pling" && event.sound.volume == 0.69f && event.sound.pitch == 1.6666666f) {
                 // This throws an error but still blocks the sound. Not a great solution, but it works for now
-                event.isCanceled = true
+                try {
+                    event.isCanceled = true
+                } catch (ignored: IllegalArgumentException) {
+                }
             }
         }
     }


### PR DESCRIPTION
Hides the useless error messages from AbiphoneDND when hiding the sound.
Sadly, only a workaround, but it's still less console spam.