### PR TITLE
Added an option to play a sound when clicking a secret in dungeons

### DIFF
--- a/src/main/kotlin/dulkirmod/DulkirMod.kt
+++ b/src/main/kotlin/dulkirmod/DulkirMod.kt
@@ -80,6 +80,7 @@ class DulkirMod {
         mcBus.register(GardenVisitorAlert)
         mcBus.register(DragonTimer)
         mcBus.register(HideHealerFairy)
+        mcBus.register(SecretSounds)
 
         keyBinds.forEach(ClientRegistry::registerKeyBinding)
     }

--- a/src/main/kotlin/dulkirmod/config/DulkirConfig.kt
+++ b/src/main/kotlin/dulkirmod/config/DulkirConfig.kt
@@ -363,6 +363,36 @@ object DulkirConfig : Config(Mod("DulkirMod", ModType.SKYBLOCK), "dulkirmod-conf
     var highlightLeapName: String = "Dilkur"
 
     @Switch(
+        name = "Play sound when clicking secrets in dungeons",
+        description = "Will play on levers, chests and essence",
+        category = "Dungeons",
+        subcategory = "Dungeons"
+    )
+    var secretClickSounds = false
+
+    @Slider(
+        name = "Secret Click Volume",
+        description = "Volume of click sound",
+        category = "Dungeons",
+        subcategory = "Dungeons",
+        min = 0f,
+        max = 1f,
+        step = 0
+    )
+    var secretSoundVolume = .7f
+
+    @Button(
+        name = "Demo Volume Selection",
+        description = "Plays the Random Break sound as Reference, Might add individual sliders later but this seems like enough",
+        category = "Dungeons",
+        subcategory = "Dungeons",
+        text = "Test"
+    )
+    fun demoSecretVolume() {
+        DulkirMod.mc.thePlayer.playSound("random.break", 1f * secretSoundVolume, 1f)
+    }
+
+    @Switch(
         name = "Remove Selfie Camera",
         description = "Get rid of pesky reverse third person!",
         category = "General",
@@ -671,6 +701,7 @@ object DulkirConfig : Config(Mod("DulkirMod", ModType.SKYBLOCK), "dulkirmod-conf
         addDependency("hurtCamIntensity", "hurtCamSlider")
         addDependency("tooltipSize", "scaledTooltips")
         addDependency("persistentAlert", "notifyMaxVisitors")
-
+        addDependency("secretSoundVolume", "secretClickSounds")
+        addDependency("demoSecretVolume", "secretClickSounds")
     }
 }

--- a/src/main/kotlin/dulkirmod/features/SecretSounds.kt
+++ b/src/main/kotlin/dulkirmod/features/SecretSounds.kt
@@ -1,0 +1,60 @@
+package dulkirmod.features
+
+import dulkirmod.DulkirMod.Companion.mc
+import dulkirmod.config.DulkirConfig
+import dulkirmod.utils.TabListUtils.isInDungeons
+import net.minecraft.block.Block
+import net.minecraft.init.Blocks
+import net.minecraft.tileentity.TileEntitySkull
+import net.minecraftforge.event.entity.player.PlayerInteractEvent
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
+
+object SecretSounds {
+    private var lastSound: Long = 0L
+    @SubscribeEvent
+    fun onInteract(event: PlayerInteractEvent) {
+        if (event.action != PlayerInteractEvent.Action.RIGHT_CLICK_BLOCK) {
+            return
+        }
+        if (!DulkirConfig.secretClickSounds) {
+            return
+        }
+        if (!isInDungeons) {
+            return
+        }
+
+
+        val blockType: Block = mc.theWorld.getBlockState(event.pos).block ?: return // get the type of block
+
+        if (blockType != Blocks.chest && blockType != Blocks.trapped_chest && blockType != Blocks.skull && blockType != Blocks.lever) { // check if it's a secret
+            return
+        }
+
+        if (blockType == Blocks.skull) { // it may be a wither essence skull
+            var skullId: String? = null
+
+            try {
+                skullId = (mc.theWorld.getTileEntity(event.pos) as TileEntitySkull).playerProfile.id.toString()
+
+            } catch (ignored: NullPointerException) {} // it doesn't have a playerID
+
+
+            if (skullId == null || skullId != "26bb1a8d-7c66-31c6-82d5-a9c04c94fb02") { // check if it is a wither essence player head
+                return
+            }
+
+        }
+        playSound()
+    }
+
+    private fun playSound() {
+        if (System.currentTimeMillis() - lastSound > 50) { // don't kill ears
+            mc.thePlayer.playSound(
+                "random.break",
+                1f * DulkirConfig.secretSoundVolume,
+                1f
+            )
+            lastSound = System.currentTimeMillis()
+        }
+    }
+}


### PR DESCRIPTION
Adjustable volume
currently still plays a sound if the player clicks a locked chest or an already opened chest, but I don't think that's a big problem