### PR TITLE
Update mcmod.info

### DIFF
--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -5,8 +5,7 @@
     "description": "The worst skyblock mod.",
     "version": "1.2.4",
     "mcversion": "1.8.9",
-    "authorList": [
-      "Dulkir"
-    ]
+    "url": "https://github.com/inglettronald/DulkirMod",
+    "authorList": ["Dulkir"]
   }
 ]


### PR DESCRIPTION
Add {"url": "https://github.com/inglettronald/DulkirMod",} to mcmod.info to make the github page more accessible within advanced launchers as shown in the pictures below:

[Hyperlink view within the launcher] https://github.com/inglettronald/DulkirMod/assets/71152763/99650dbe-72ec-425e-8f8d-dcbffb08eca6
[Github page displayed upon clicking the hyperlink] https://github.com/inglettronald/DulkirMod/assets/71152763/d276bef8-74c8-4294-83c5-da4530738595
