### PR TITLE
Fix hide opened chests in croesus feature not working

### DIFF
--- a/src/main/kotlin/dulkirmod/features/dungeons/Croesus.kt
+++ b/src/main/kotlin/dulkirmod/features/dungeons/Croesus.kt
@@ -48,7 +48,7 @@ object Croesus {
 
 				val tagList: NBTTagList = stack.getSubCompound("display", false)?.getTagList("Lore", 8) ?: continue
 				for (j in 0 until tagList.tagCount()) {
-					if (tagList.getStringTagAt(j) == "§aChests have been opened!") boolArray[i - 9] = true
+					if (tagList.getStringTagAt(j) == "§aNo more Chests to open!") boolArray[i - 9] = true
 				}
 			}
 		}


### PR DESCRIPTION
Stopped working after one of the last skyblock patches where they changed the opened text. This updates the feature to search for the new text in the item lore, which fixes and makes the feature work again.

Line ending change because I created the commit from GitHub web overlay. It should be harmless.