### PR TITLE
Use single regex instead of 3 different ones in bridge formatter and fixed mod incompatibility

### DIFF
--- a/src/main/kotlin/dulkirmod/features/chat/Bridge.kt
+++ b/src/main/kotlin/dulkirmod/features/chat/Bridge.kt
@@ -8,17 +8,13 @@ import net.minecraftforge.client.event.ClientChatReceivedEvent
 
 object Bridge {
     private val guildFormat =
-        "^(§2Guild|§3Officer) > (?:\\S+ )?([\\w§]{3,18})(?: §[a-z0-9]\\[[A-Z]+])?§f: ([^>]+) > .+".toRegex()
-    private val alternateFormat =
-        "^(§2Guild|§3Officer) > (?:\\S+ )?([\\w§]{3,18})(?: §[a-z0-9]\\[[A-Z]+])?§f: ([^:]+): .+".toRegex()
-    private val otherAltFormat =
-        "^(§2Guild|§3Officer) > (?:\\S+ )?([\\w§]{3,18})(?: §[a-z0-9]\\[[A-Z]+])?§f: ([^»]+) » .+".toRegex()
+        "^(?:§r|)(§2Guild|§3Officer) > (?:\\S+ )?([\\w§]{3,18})(?: §[a-z0-9]\\[[\\w]+])?§f: ([^»>:]+)( » | > |: ).+".toRegex()
 
     fun handle(event: ClientChatReceivedEvent) {
         val message = event.message.unformattedText
         if (guildFormat matches message && DulkirConfig.bridgeBot) {
             val matchResult = guildFormat.find(message)
-            val (prefix, name, playerName) = matchResult!!.destructured
+            val (prefix, name, playerName, separator) = matchResult!!.destructured
             if (Utils.stripColorCodes(name.lowercase()) == DulkirConfig.botName.lowercase()) {
                 val newPrefix = if (prefix == "§2Guild") "§2Bridge" else "§3Bridge"
                 val color = if (DulkirConfig.bridgeColor == 16) "§z" else EnumChatFormatting.values()[DulkirConfig.bridgeColor]
@@ -26,38 +22,7 @@ object Bridge {
                     "$newPrefix > $color$playerName§f: "
                 )
                 event.message.siblings[1] = ChatComponentText(
-                    event.message.siblings[1].unformattedText.replace("$playerName > ", "")
-                ).setChatStyle(event.message.siblings[1].chatStyle.createShallowCopy())
-            }
-        }
-
-        // OTHER FORMAT
-        else if (alternateFormat matches message && DulkirConfig.bridgeBot) {
-            val matchResult = alternateFormat.find(message)
-            val (prefix, name, playerName) = matchResult!!.destructured
-            if (Utils.stripColorCodes(name.lowercase()) == DulkirConfig.botName.lowercase()) {
-                val newPrefix = if (prefix == "§2Guild") "§2Bridge" else "§3Bridge"
-                val color = if (DulkirConfig.bridgeColor == 16) "§z" else EnumChatFormatting.values()[DulkirConfig.bridgeColor]
-                event.message.siblings[0] = ChatComponentText(
-                    "$newPrefix > $color$playerName§f: "
-                )
-                event.message.siblings[1] = ChatComponentText(
-                    event.message.siblings[1].unformattedText.replace("$playerName: ", "")
-                ).setChatStyle(event.message.siblings[1].chatStyle.createShallowCopy())
-            }
-        }
-
-        else if (otherAltFormat matches message && DulkirConfig.bridgeBot) {
-            val matchResult = otherAltFormat.find(message)
-            val (prefix, name, playerName) = matchResult!!.destructured
-            if (Utils.stripColorCodes(name.lowercase()) == DulkirConfig.botName.lowercase()) {
-                val newPrefix = if (prefix == "§2Guild") "§2Bridge" else "§3Bridge"
-                val color = if (DulkirConfig.bridgeColor == 16) "§z" else EnumChatFormatting.values()[DulkirConfig.bridgeColor]
-                event.message.siblings[0] = ChatComponentText(
-                    "$newPrefix > $color$playerName§f: "
-                )
-                event.message.siblings[1] = ChatComponentText(
-                    event.message.siblings[1].unformattedText.replace("$playerName » ", "")
+                    event.message.siblings[1].unformattedText.replace("$playerName$separator", "")
                 ).setChatStyle(event.message.siblings[1].chatStyle.createShallowCopy())
             }
         }


### PR DESCRIPTION
The mod incompatibilities are that im not sure which mod it is, but a friend of mine was having an issue with a certain mod that adds a `§r` at the beginning of the guild message, this should also take care of that.